### PR TITLE
Custom blank symbol

### DIFF
--- a/ctcdecode/__init__.py
+++ b/ctcdecode/__init__.py
@@ -12,10 +12,11 @@ class CTCBeamDecoder(object):
         self._labels = ''.join(labels).encode()
         self._num_labels = len(labels)
         self._blank_id = blank_id
-	self._space_symbol=space_symbol
+        self._space_symbol = space_symbol
+        
         if model_path:
             self._scorer = ctc_decode.paddle_get_scorer(alpha, beta, model_path.encode(), self._labels,
-                                                        self._num_labels,space_symbol)
+                                                        self._num_labels, self._space_symbol.encode())
         self._cutoff_prob = cutoff_prob
 
     def decode(self, probs, seq_lens=None):
@@ -32,11 +33,12 @@ class CTCBeamDecoder(object):
         out_seq_len = torch.IntTensor(batch_size, self._beam_width).cpu().int()
         if self._scorer:
             ctc_decode.paddle_beam_decode_lm(probs, seq_lens, self._labels, self._num_labels, self._beam_width,
-                                             self._num_processes, self._cutoff_prob, self.cutoff_top_n, self._blank_id,self._space_symbol,	
+                                             self._num_processes, self._cutoff_prob, self.cutoff_top_n, self._blank_id,
+                                             self._space_symbol.encode(),	
                                              self._scorer, output, timesteps, scores, out_seq_len)
         else:
             ctc_decode.paddle_beam_decode(probs, seq_lens, self._labels, self._num_labels, self._beam_width, self._num_processes,
-                                          self._cutoff_prob, self.cutoff_top_n, self._blank_id, self._space_symbol, output, timesteps,
+                                          self._cutoff_prob, self.cutoff_top_n, self._blank_id, self._space_symbol.encode(), output, timesteps,
                                           scores, out_seq_len)
 
         return output, scores, timesteps, out_seq_len

--- a/ctcdecode/src/binding.h
+++ b/ctcdecode/src/binding.h
@@ -7,6 +7,7 @@ int paddle_beam_decode(THFloatTensor *th_probs,
                        double cutoff_prob,
                        size_t cutoff_top_n,
                        size_t blank_id,
+		       const char* space_symbol,
                        THIntTensor *th_output,
                        THIntTensor *th_timesteps,
                        THFloatTensor *th_scores,
@@ -21,6 +22,7 @@ int paddle_beam_decode_lm(THFloatTensor *th_probs,
                           double cutoff_prob,
                           size_t cutoff_top_n,
                           size_t blank_id,
+			  const char* space_symbol,
                           void *scorer,
                           THIntTensor *th_output,
                           THIntTensor *th_timesteps,
@@ -31,7 +33,8 @@ void* paddle_get_scorer(double alpha,
                         double beta,
                         const char* lm_path,
                         const char* labels,
-                        int vocab_size);
+                        int vocab_size, 
+			const char* space_symbol);
 
 int is_character_based(void *scorer);
 size_t get_max_order(void *scorer);

--- a/ctcdecode/src/ctc_beam_search_decoder.cpp
+++ b/ctcdecode/src/ctc_beam_search_decoder.cpp
@@ -21,6 +21,7 @@ std::vector<std::pair<double, Output>> ctc_beam_search_decoder(
     double cutoff_prob,
     size_t cutoff_top_n,
     size_t blank_id,
+    const std::string &space_symbol,
     Scorer *ext_scorer) {
   // dimension check
   size_t num_time_steps = probs_seq.size();
@@ -35,7 +36,9 @@ std::vector<std::pair<double, Output>> ctc_beam_search_decoder(
   // size_t blank_id = vocabulary.size();
 
   // assign space id
-  auto it = std::find(vocabulary.begin(), vocabulary.end(), " ");
+  // Changed by Gideon from the blank symbol " " to a custom symbol specified as argument
+  auto it = std::find(vocabulary.begin(), vocabulary.end(), space_symbol);
+  //auto it = std::find(vocabulary.begin(), vocabulary.end(), " ");
   int space_id = it - vocabulary.begin();
   // if no space in vocabulary
   if ((size_t)space_id >= vocabulary.size()) {
@@ -174,7 +177,7 @@ std::vector<std::pair<double, Output>> ctc_beam_search_decoder(
       std::vector<int> timesteps;
       prefixes[i]->get_path_vec(output, timesteps);
       auto prefix_length = output.size();
-      auto words = ext_scorer->split_labels(output);
+      auto words = ext_scorer->split_labels(output, space_symbol);
       // remove word insert
       approx_ctc = approx_ctc - prefix_length * ext_scorer->beta;
       // remove language model weight:
@@ -196,6 +199,7 @@ ctc_beam_search_decoder_batch(
     double cutoff_prob,
     size_t cutoff_top_n,
     size_t blank_id,
+    const std::string &space_symbol,
     Scorer *ext_scorer) {
   VALID_CHECK_GT(num_processes, 0, "num_processes must be nonnegative!");
   // thread pool
@@ -213,6 +217,7 @@ ctc_beam_search_decoder_batch(
                                   cutoff_prob,
                                   cutoff_top_n,
                                   blank_id,
+				  space_symbol,
                                   ext_scorer));
   }
 

--- a/ctcdecode/src/ctc_beam_search_decoder.h
+++ b/ctcdecode/src/ctc_beam_search_decoder.h
@@ -25,6 +25,8 @@
  *     in desending order.
 */
 
+const std::string DEFAULT_SPACE_SYMBOL =  std::string(" ");
+
 std::vector<std::pair<double, Output>> ctc_beam_search_decoder(
     const std::vector<std::vector<double>> &probs_seq,
     const std::vector<std::string> &vocabulary,
@@ -32,6 +34,7 @@ std::vector<std::pair<double, Output>> ctc_beam_search_decoder(
     double cutoff_prob = 1.0,
     size_t cutoff_top_n = 40,
     size_t blank_id = 0,
+    const std::string &space_symbol = DEFAULT_SPACE_SYMBOL,	 
     Scorer *ext_scorer = nullptr);
 
 /* CTC Beam Search Decoder for batch data
@@ -44,6 +47,7 @@ std::vector<std::pair<double, Output>> ctc_beam_search_decoder(
  *     num_processes: Number of threads for beam search.
  *     cutoff_prob: Cutoff probability for pruning.
  *     cutoff_top_n: Cutoff number for pruning.
+ *     space_symbol: The symbol used to indicate spaces, default is " ".
  *     ext_scorer: External scorer to evaluate a prefix, which consists of
  *                 n-gram language model scoring and word insertion term.
  *                 Default null, decoding the input sample without scorer.
@@ -60,6 +64,7 @@ ctc_beam_search_decoder_batch(
     double cutoff_prob = 1.0,
     size_t cutoff_top_n = 40,
     size_t blank_id = 0,
+    const std::string &space_symbol = DEFAULT_SPACE_SYMBOL,
     Scorer *ext_scorer = nullptr);
 
 #endif  // CTC_BEAM_SEARCH_DECODER_H_

--- a/ctcdecode/src/decoder_utils.cpp
+++ b/ctcdecode/src/decoder_utils.cpp
@@ -153,7 +153,8 @@ bool add_word_to_dictionary(
   std::vector<int> int_word;
 
   for (auto &c : characters) {
-    if (c == " ") {
+    // if (c == " ") {
+    if (c == "|") {   // Gideon: replaced the space symbol " " => "|"
       int_word.push_back(SPACE_ID);
     } else {
       auto int_c = char_map.find(c);

--- a/ctcdecode/src/scorer.h
+++ b/ctcdecode/src/scorer.h
@@ -43,7 +43,8 @@ public:
   Scorer(double alpha,
          double beta,
          const std::string &lm_path,
-         const std::vector<std::string> &vocabulary);
+         const std::vector<std::string> &vocabulary,
+         const std::string &space_symbol);
   ~Scorer();
 
   double get_log_cond_prob(const std::vector<std::string> &words);
@@ -67,7 +68,7 @@ public:
 
   // trransform the labels in index to the vector of words (word based lm) or
   // the vector of characters (character based lm)
-  std::vector<std::string> split_labels(const std::vector<int> &labels);
+  std::vector<std::string> split_labels(const std::vector<int> &labels, const std::string &space_symbol);
 
   // language model weight
   double alpha;
@@ -80,7 +81,8 @@ public:
 protected:
   // necessary setup: load language model, set char map, fill FST's dictionary
   void setup(const std::string &lm_path,
-             const std::vector<std::string> &vocab_list);
+             const std::vector<std::string> &vocab_list,
+             const std::string &space_symbo);
 
   // load language model from given path
   void load_lm(const std::string &lm_path);
@@ -89,7 +91,7 @@ protected:
   void fill_dictionary(bool add_space);
 
   // set char map
-  void set_char_map(const std::vector<std::string> &char_list);
+  void set_char_map(const std::vector<std::string> &char_list, const std::string &space_symbol);
 
   double get_log_prob(const std::vector<std::string> &words);
 


### PR DESCRIPTION
I added an extra argument to the decoders to allow specification of a custom space symbol. Currently the space symbol used by the decoder is hard-coded to be " ". This is probably fine in most cases, but it does not work for example for my problem domain of handwriting recognition, in which the word separator can be a special symbol such as "|" and the normal space symbol " " may be not used at all.