### PR TITLE
fix for character level language models

### DIFF
--- a/ctcdecode/src/scorer.cpp
+++ b/ctcdecode/src/scorer.cpp
@@ -170,7 +170,7 @@ std::vector<std::string> Scorer::make_ngram(PathTrie* prefix) {
     std::vector<int> prefix_steps;
 
     if (is_character_based_) {
-      new_node = current_node->get_path_vec(prefix_vec, prefix_steps, SPACE_ID_, 1);
+      new_node = current_node->get_path_vec(prefix_vec, prefix_steps, -1, 1);
       current_node = new_node;
     } else {
       new_node = current_node->get_path_vec(prefix_vec, prefix_steps, SPACE_ID_);


### PR DESCRIPTION
Currently character level language model skips spaces, so all output sequences are without the space character. This should fix that.