### PR TITLE
Feature/import alphabet as list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ build
 _ext
 ctc_decode
 *.pyc
-
+.idea
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/ctcdecode/__init__.py
+++ b/ctcdecode/__init__.py
@@ -9,7 +9,7 @@ class CTCBeamDecoder(object):
         self._beam_width = beam_width
         self._scorer = None
         self._num_processes = num_processes
-        self._labels = ''.join(labels).encode()
+        self._labels = labels
         self._num_labels = len(labels)
         self._blank_id = blank_id
         self._log_probs = 1 if log_probs_input else 0
@@ -33,9 +33,10 @@ class CTCBeamDecoder(object):
         if self._scorer:
             ctc_decode.paddle_beam_decode_lm(probs, seq_lens, self._labels, self._num_labels, self._beam_width,
                                              self._num_processes, self._cutoff_prob, self.cutoff_top_n, self._blank_id,
-                                             self._log_probs ,self._scorer, output, timesteps, scores, out_seq_len)
+                                             self._log_probs, self._scorer, output, timesteps, scores, out_seq_len)
         else:
-            ctc_decode.paddle_beam_decode(probs, seq_lens, self._labels, self._num_labels, self._beam_width, self._num_processes,
+            ctc_decode.paddle_beam_decode(probs, seq_lens, self._labels, self._num_labels, self._beam_width,
+                                          self._num_processes,
                                           self._cutoff_prob, self.cutoff_top_n, self._blank_id, self._log_probs,
                                           output, timesteps, scores, out_seq_len)
 

--- a/ctcdecode/src/binding.h
+++ b/ctcdecode/src/binding.h
@@ -1,6 +1,6 @@
 int paddle_beam_decode(THFloatTensor *th_probs,
                        THIntTensor *th_seq_lens,
-                       const char* labels,
+                       std::vector<std::string> labels,
                        int vocab_size,
                        size_t beam_size,
                        size_t num_processes,
@@ -13,9 +13,10 @@ int paddle_beam_decode(THFloatTensor *th_probs,
                        THFloatTensor *th_scores,
                        THIntTensor *th_out_length);
 
+
 int paddle_beam_decode_lm(THFloatTensor *th_probs,
                           THIntTensor *th_seq_lens,
-                          const char* labels,
+                          std::vector<std::string> labels,
                           int vocab_size,
                           size_t beam_size,
                           size_t num_processes,
@@ -32,7 +33,7 @@ int paddle_beam_decode_lm(THFloatTensor *th_probs,
 void* paddle_get_scorer(double alpha,
                         double beta,
                         const char* lm_path,
-                        const char* labels,
+                        std::vector<std::string> labels,
                         int vocab_size);
 
 void paddle_release_scorer(void* scorer);


### PR DESCRIPTION
This feature uses the boost package to import the labels of the acoustic model into ctcdecode as a list rather than a string. This allows ctcdecode to go from only working with single-byte characters to also working with multi-byte characters and subword units. 