### PR TITLE
Multi-process build based on the number of cpu cores available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def parallelCCompile(self,
         self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
 
     # convert to list, imap is evaluated on-demand
-    thread_pool = multiprocessing.pool.ThreadPool(4)
+    thread_pool = multiprocessing.pool.ThreadPool(os.cpu_count())
     list(thread_pool.imap(_single_compile, objects))
     return objects
 


### PR DESCRIPTION
This is needed to run the build on lower CPU machines (like DockerHub resources).