### PR TITLE
initialize out_seq_len tensor as zeros

### DIFF
--- a/ctcdecode/__init__.py
+++ b/ctcdecode/__init__.py
@@ -29,7 +29,7 @@ class CTCBeamDecoder(object):
         output = torch.IntTensor(batch_size, self._beam_width, max_seq_len).cpu().int()
         timesteps = torch.IntTensor(batch_size, self._beam_width, max_seq_len).cpu().int()
         scores = torch.FloatTensor(batch_size, self._beam_width).cpu().float()
-        out_seq_len = torch.IntTensor(batch_size, self._beam_width).cpu().int()
+        out_seq_len = torch.zeros(batch_size, self._beam_width).cpu().int()
         if self._scorer:
             ctc_decode.paddle_beam_decode_lm(probs, seq_lens, self._labels, self._num_labels, self._beam_width,
                                              self._num_processes, self._cutoff_prob, self.cutoff_top_n, self._blank_id,


### PR DESCRIPTION
When the beam_width exceeds the number of possible hypotheses for a given number of frames and alphabet size, the out_seq_len tensor can be nonsensical initialization values rather than 0, which makes more sense for non-existent paths