### PR TITLE
Fix clang compilation

### DIFF
--- a/ctcdecode/src/binding.cpp
+++ b/ctcdecode/src/binding.cpp
@@ -201,8 +201,8 @@ std::pair<torch::Tensor, torch::Tensor> beam_decode_with_given_state(at::Tensor 
         }
         }
     
-    torch::Tensor output_tokens_tensor = torch::randint(1, {batch_results.size(), max_result_size, max_output_tokens_size});
-    torch::Tensor output_timesteps_tensor = torch::randint(1, {batch_results.size(), max_result_size, max_output_tokens_size});
+    torch::Tensor output_tokens_tensor = torch::randint(1, {static_cast<long long>(batch_results.size()), max_result_size, max_output_tokens_size});
+    torch::Tensor output_timesteps_tensor = torch::randint(1, {static_cast<long long>(batch_results.size()), max_result_size, max_output_tokens_size});
 
 
     auto scores_accessor =  th_scores.accessor<float, 2>();

--- a/ctcdecode/src/decoder_utils.cpp
+++ b/ctcdecode/src/decoder_utils.cpp
@@ -3,7 +3,9 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
-#include <bits/stdc++.h>
+#include <vector>
+#include <unordered_map>
+
 using namespace std;
 
 


### PR DESCRIPTION
Replace gcc specific header `bits/stdc++` with compiler agnostic headers so we can compile the decoder with clang on OS X
Fix static cast compilation error