### PR TITLE
Fix NoneType object is not callable in CTCBeamDecoder

### DIFF
--- a/ctcdecode/__init__.py
+++ b/ctcdecode/__init__.py
@@ -136,7 +136,7 @@ class CTCBeamDecoder(object):
             ctc_decode.reset_params(self._scorer, alpha, beta)
 
     def __del__(self):
-        if self._scorer is not None:
+        if self._scorer is not None and not ctc_decode.paddle_release_scorer is None:
             ctc_decode.paddle_release_scorer(self._scorer)
 
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ def compile_test(header, library):
     return os.system(command) == 0
 
 
-compile_args = ["-O3", "-DKENLM_MAX_ORDER=6", "-std=c++14", "-fPIC"]
+compile_args = ["-O3", "-DKENLM_MAX_ORDER=6", "-std=c++17", "-fPIC"]
 ext_libs = []
 if compile_test("zlib.h", "z"):
     compile_args.append("-DHAVE_ZLIB")


### PR DESCRIPTION
I always get this error when I use keyboard interruption
```
KeyboardInterrupt:                                                                                                                                                                     
Exception ignored in: <function CTCBeamDecoder.__del__ at 0x7fd1389638b0>                                                                                                              
Traceback (most recent call last):
  File "/opt/conda/lib/python3.8/site-packages/ctcdecode/__init__.py", line 140, in __del__ 
TypeError: 'NoneType' object is not callable  
```
This commit aims to solve this issue